### PR TITLE
Add http api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,1 @@
+package api

--- a/api/api.go
+++ b/api/api.go
@@ -1,1 +1,33 @@
 package api
+
+import (
+	"net/http"
+)
+
+// MetadataClient is a helper client used to augment the metadata of the user
+// and channel extracted from the registered token.
+type MetadataClient interface {
+	GetUser(string) string
+	GetChannel(string) string
+	IsIM(string) string
+}
+
+// Server is used to provide API access
+type Server struct {
+	metadata MetadataClient
+}
+
+// NewServer returns a new API Server that will use the provided metadata client
+func NewServer(client MetadataClient) Server {
+	return Server{
+		metadata: client,
+	}
+}
+
+// Listen starts listening
+func (s Server) Listen(path, address string) {
+	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+
+	})
+	http.ListenAndServe(address, nil)
+}

--- a/api/api.go
+++ b/api/api.go
@@ -13,8 +13,10 @@ import (
 // MetadataClient is a helper client used to augment the metadata of the user
 // and channel extracted from the registered token.
 type MetadataClient interface {
-	GetUser(string) string
+	GetUsername(string) string
+	GetUserLink(string) string
 	GetChannel(string) string
+	GetChannelLink(string) string
 	IsIM(string) bool
 }
 
@@ -42,6 +44,7 @@ func (l Listener) ListenMessages(ch chan<- message.Message) {
 
 // Shutdown closes the internal messages channel
 func (l Listener) Shutdown() {
+	logrus.Infof("Shutting down API messages channel")
 	close(l.messageCh)
 }
 
@@ -83,6 +86,8 @@ func (s *Server) GetListener() Listener {
 // Shutdown shuts down the http server gracefully
 func (s *Server) Shutdown() error {
 	defer s.listener.Shutdown()
+	logrus.Infof("Shutting down API server")
+
 	return s.httpServer.Shutdown(nil)
 }
 
@@ -125,31 +130,36 @@ func (m apiMessage) GetText() string {
 }
 
 // GetUsernameID returns the user id formatted for using in a slack message
-func (m apiMessage) GetUsernameID() string {
-	return m.token.User
+func (m apiMessage) GetUserID() string {
+	return m.token.UserID
 }
 
 // GetUsername returns the user friendly username
 func (m apiMessage) GetUsername() string {
-	return m.metadata.GetUser(m.token.User)
+	return m.metadata.GetUsername(m.token.UserID)
+}
+
+// GetUserLink
+func (m apiMessage) GetUserLink() string {
+	return m.metadata.GetUserLink(m.token.UserID)
 }
 
 // GetChannelID returns the channel id from the which the message was sent
 func (m apiMessage) GetChannelID() string {
-	return m.token.Channel
+	return m.token.ChannelID
 }
 
 // GetChannel returns the channel from which the message was sent
 func (m apiMessage) GetChannel() string {
-	return m.metadata.GetChannel(m.token.Channel)
+	return m.metadata.GetChannel(m.token.ChannelID)
 }
 
 // GetChannelLink returns the channel that slack will turn into a link
 func (m apiMessage) GetChannelLink() string {
-	return m.metadata.GetChannel(m.token.Channel)
+	return m.metadata.GetChannelLink(m.token.ChannelID)
 }
 
 // IsIM returns if the message is an IM message
 func (m apiMessage) IsIM() bool {
-	return m.metadata.IsIM(m.token.Channel)
+	return m.metadata.IsIM(m.token.ChannelID)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -14,6 +14,7 @@ import (
 // and channel extracted from the registered token.
 type MetadataClient interface {
 	ParseChannelLink(string) (string, error)
+	ParseUserLink(string) (string, error)
 	GetUsername(string) string
 	GetUserLink(string) string
 	GetChannel(string) string
@@ -36,9 +37,16 @@ func (l Listener) sendMessage(token tokens.Token, message string) {
 		// TODO: this error should go to the administration channel
 	}
 
+	userID, err := l.metadata.ParseUserLink(token.UserLink)
+	if err != nil {
+		logrus.Errorf("Failed to parse user link %s: %s. Dropping message!", token.UserLink, err)
+		return
+		// TODO: this error should go to the administration channel
+	}
+
 	m := apiMessage{
 		channelID:      channelID,
-		userID:         token.UserID,
+		userID:         userID,
 		text:           token.Text,
 		metadata:       l.metadata,
 		messagePayload: message,

--- a/api/api.go
+++ b/api/api.go
@@ -2,6 +2,11 @@ package api
 
 import (
 	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/pcarranza/meeseeks-box/meeseeks/message"
+	"github.com/pcarranza/meeseeks-box/tokens"
 )
 
 // MetadataClient is a helper client used to augment the metadata of the user
@@ -9,25 +14,98 @@ import (
 type MetadataClient interface {
 	GetUser(string) string
 	GetChannel(string) string
-	IsIM(string) string
+	IsIM(string) bool
 }
 
 // Server is used to provide API access
 type Server struct {
-	metadata MetadataClient
+	metadata  MetadataClient
+	messageCh chan message.Message
 }
 
 // NewServer returns a new API Server that will use the provided metadata client
 func NewServer(client MetadataClient) Server {
 	return Server{
-		metadata: client,
+		metadata:  client,
+		messageCh: make(chan message.Message),
 	}
 }
 
 // Listen starts listening
 func (s Server) Listen(path, address string) {
-	http.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(path, s.HandlePostToken)
+	go http.ListenAndServe(address, nil)
+}
 
-	})
-	http.ListenAndServe(address, nil)
+// Handle handles a request
+func (s Server) HandlePostToken(w http.ResponseWriter, r *http.Request) {
+	tokenID := r.Header.Get("TOKEN")
+	if tokenID == "" {
+		http.Error(w, "no token", http.StatusBadRequest)
+		return
+	}
+	logrus.Debugf("received token %s through API", tokenID) // Add requester info
+
+	token, err := tokens.Get(tokenID)
+	if err != nil {
+		logrus.Debugf("Token %s is unknown", token) // Add requester info
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+
+	logrus.Infof("received valid token %s from", token)
+	s.messageCh <- apiMessage{
+		metadata: s.metadata,
+		token:    token,
+	}
+
+	w.WriteHeader(http.StatusAccepted)
+}
+
+// ListenMessages listens to messages and sends the matching ones through the channel
+func (s Server) ListenMessages(ch chan<- message.Message) {
+	for m := range s.messageCh {
+		ch <- m
+	}
+}
+
+// Message a chat message
+type apiMessage struct {
+	token    tokens.Token
+	metadata MetadataClient
+}
+
+// GetText returns the message text
+func (m apiMessage) GetText() string {
+	return m.token.Text
+}
+
+// GetUsernameID returns the user id formatted for using in a slack message
+func (m apiMessage) GetUsernameID() string {
+	return m.token.User
+}
+
+// GetUsername returns the user friendly username
+func (m apiMessage) GetUsername() string {
+	return m.metadata.GetUser(m.token.User)
+}
+
+// GetChannelID returns the channel id from the which the message was sent
+func (m apiMessage) GetChannelID() string {
+	return m.token.Channel
+}
+
+// GetChannel returns the channel from which the message was sent
+func (m apiMessage) GetChannel() string {
+	return m.metadata.GetChannel(m.token.Channel)
+}
+
+// GetChannelLink returns the channel that slack will turn into a link
+func (m apiMessage) GetChannelLink() string {
+	return m.metadata.GetChannel(m.token.Channel)
+}
+
+// IsIM returns if the message is an IM message
+func (m apiMessage) IsIM() bool {
+	return m.metadata.IsIM(m.token.Channel)
 }

--- a/api/api.go
+++ b/api/api.go
@@ -28,11 +28,13 @@ type Listener struct {
 }
 
 func (l Listener) sendMessage(token tokens.Token, message string) {
-	l.messageCh <- apiMessage{
+	m := apiMessage{
 		metadata:    l.metadata,
 		token:       token,
 		formMessage: message,
 	}
+	logrus.Debugf("Sending API message %#v to messages channel", m)
+	l.messageCh <- m
 }
 
 // ListenMessages listens to messages and sends the matching ones through the channel

--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 
+	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 
 	"github.com/pcarranza/meeseeks-box/meeseeks/message"
@@ -37,7 +38,7 @@ func (s Server) Listen(path, address string) {
 	go http.ListenAndServe(address, nil)
 }
 
-// Handle handles a request
+// HandlePostToken handles a request
 func (s Server) HandlePostToken(w http.ResponseWriter, r *http.Request) {
 	tokenID := r.Header.Get("TOKEN")
 	if tokenID == "" {
@@ -52,6 +53,7 @@ func (s Server) HandlePostToken(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusUnauthorized)
 		return
 	}
+	log.Infof("token is %#v", token)
 
 	logrus.Infof("received valid token %s from", token)
 	s.messageCh <- apiMessage{

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -10,53 +10,53 @@ import (
 	"github.com/pcarranza/meeseeks-box/meeseeks/message"
 	"github.com/pcarranza/meeseeks-box/tokens"
 
-	/*
-	   # API
-
-	   ## Will need
-
-	   * a token that links to a user+command+channel
-	   * a command to create a token
-	   * a command to revoke a token
-	   * a command to list tokens with commands
-
-	   ## Steps to enable the API
-
-	   1. Configuration: the endpoint in which to listen, namely address and path.
-	   2. Enabling: using a command, pass in the command that the API will be
-	   calling and the channel in which to reply, else it will be considered as an
-	   IM
-	   3. The command will need to resolve the channel <token> (the client will need to provide this)
-	   4. This command can only be called over IM
-	   5. ~The api enabling will need to test that the user has access to the requested command?~ (nah... late binding)
-
-	   ## Token data model
-
-	   - Tokens
-	     - Token (something something UUID hash)
-	       - UserID
-	       - ChannelID
-	       - Command
-	       - Args
-
-	   ### Interface
-
-	   - Create{payload} - returns the token
-	   - Get{Token}
-	   - List{UserID}
-
-	   # Steps to build:
-
-	   1. Create the data model
-	   2. Add the creation and the Get methods
-	   3. Add the http interface to post the token, return 200 when found
-	   4. Pipe the message to the stub client, check it works
-	   5. Finish implementation
-
-	*/
-
 	stubs "github.com/pcarranza/meeseeks-box/testingstubs"
 )
+
+/*
+   # API
+
+   ## Will need
+
+   * a token that links to a user+command+channel
+   * a command to create a token
+   * a command to revoke a token
+   * a command to list tokens with commands
+
+   ## Steps to enable the API
+
+   1. Configuration: the endpoint in which to listen, namely address and path.
+   2. Enabling: using a command, pass in the command that the API will be
+   calling and the channel in which to reply, else it will be considered as an
+   IM
+   3. The command will need to resolve the channel <token> (the client will need to provide this)
+   4. This command can only be called over IM
+   5. ~The api enabling will need to test that the user has access to the requested command?~ (nah... late binding)
+
+   ## Token data model
+
+   - Tokens
+     - Token (something something UUID hash)
+       - UserID
+       - ChannelID
+       - Command
+       - Args
+
+   ### Interface
+
+   - Create{payload} - returns the token
+   - Get{Token}
+   - List{UserID}
+
+   # Steps to build:
+
+   1. Create the data model
+   2. Add the creation and the Get methods
+   3. Add the http interface to post the token, return 200 when found
+   4. Pipe the message to the stub client, check it works
+   5. Finish implementation
+
+*/
 
 func TestAPIServer(t *testing.T) {
 	stubs.Must(t, "failed to create a temporary DB", stubs.WithTmpDB(func(dbpath string) {

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,53 @@
+package api_test
+
+import (
+	"testing"
+)
+
+/*
+# API
+
+## Will need
+
+* a token that links to a user+command+channel
+* a command to create a token
+* a command to revoke a token
+* a command to list tokens with commands
+
+## Steps to enable the API
+
+1. Configuration: the endpoint in which to listen, namely address and path.
+2. Enabling: using a command, pass in the command that the API will be
+calling and the channel in which to reply, else it will be considered as an
+IM
+3. The command will need to resolve the channel <token> (the client will need to provide this)
+4. This command can only be called over IM
+5. ~The api enabling will need to test that the user has access to the requested command?~ (nah... late binding)
+
+## Token data model
+
+- Tokens
+  - Token (something something UUID hash)
+    - UserID
+    - ChannelID
+    - Command
+    - Args
+
+### Interface
+
+- Create{payload} - returns the token
+- Get{Token}
+- List{UserID}
+
+# Steps to build:
+
+1. Create the data model
+2. Add the creation and the Get methods
+3. Add the http interface to post the token, return 200 when found
+4. Pipe the message to the stub client, check it works
+5. Finish implementation
+
+*/
+
+func TestSomething(t *testing.T) {
+}

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -74,10 +74,11 @@ func TestAPIServer(t *testing.T) {
 
 		s := api.NewServer(stubs.MetadataStub{
 			IM: false,
-		})
+		}, ":0")
+		defer s.Shutdown()
 
 		ch := make(chan message.Message)
-		go s.ListenMessages(ch)
+		go s.GetListener().ListenMessages(ch)
 
 		testSrv := httptest.NewServer(http.HandlerFunc(s.HandlePostToken))
 

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -66,9 +66,9 @@ func TestAPIServer(t *testing.T) {
 		stubs.NewHarness().WithEchoCommand().WithDBPath(dbpath).Load()
 
 		tk, err := tokens.Create(tokens.NewTokenRequest{
-			UserID:    "someone",
-			Text:      "echo something",
-			ChannelID: "generalID",
+			UserID:      "someone",
+			ChannelLink: "generalLink",
+			Text:        "echo something",
 		})
 		stubs.Must(t, "failed to create the token", err)
 
@@ -120,9 +120,9 @@ func TestAPIServer(t *testing.T) {
 				func(t *testing.T, ch chan message.Message) {
 					msg := <-ch
 					stubs.AssertEquals(t, "echo something", msg.GetText())
-					stubs.AssertEquals(t, "generalID", msg.GetChannelID())
-					stubs.AssertEquals(t, "name: generalID", msg.GetChannel())
-					stubs.AssertEquals(t, "<#generalID>", msg.GetChannelLink())
+					stubs.AssertEquals(t, "generalLink", msg.GetChannelID())
+					stubs.AssertEquals(t, "name: generalLink", msg.GetChannel())
+					stubs.AssertEquals(t, "<#generalLink>", msg.GetChannelLink())
 					stubs.AssertEquals(t, "name: someone", msg.GetUsername())
 					stubs.AssertEquals(t, "<@someone>", msg.GetUserLink())
 					stubs.AssertEquals(t, "someone", msg.GetUserID())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -66,7 +66,7 @@ func TestAPIServer(t *testing.T) {
 		stubs.NewHarness().WithEchoCommand().WithDBPath(dbpath).Load()
 
 		tk, err := tokens.Create(tokens.NewTokenRequest{
-			UserID:      "someone",
+			UserLink:    "someoneLink",
 			ChannelLink: "generalLink",
 			Text:        "echo something",
 		})
@@ -120,9 +120,9 @@ func TestAPIServer(t *testing.T) {
 				func(t *testing.T, ch chan message.Message) {
 					msg := <-ch
 					stubs.AssertEquals(t, "echo something", msg.GetText())
-					stubs.AssertEquals(t, "generalLink", msg.GetChannelID())
-					stubs.AssertEquals(t, "name: generalLink", msg.GetChannel())
-					stubs.AssertEquals(t, "<#generalLink>", msg.GetChannelLink())
+					stubs.AssertEquals(t, "general", msg.GetChannelID())
+					stubs.AssertEquals(t, "name: general", msg.GetChannel())
+					stubs.AssertEquals(t, "<#general>", msg.GetChannelLink())
 					stubs.AssertEquals(t, "name: someone", msg.GetUsername())
 					stubs.AssertEquals(t, "<@someone>", msg.GetUserLink())
 					stubs.AssertEquals(t, "someone", msg.GetUserID())

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -66,9 +66,9 @@ func TestAPIServer(t *testing.T) {
 		stubs.NewHarness().WithEchoCommand().WithDBPath(dbpath).Load()
 
 		tk, err := tokens.Create(tokens.NewTokenRequest{
-			User:    "someone",
-			Text:    "echo something",
-			Channel: "generalID",
+			UserID:    "someone",
+			Text:      "echo something",
+			ChannelID: "generalID",
 		})
 		stubs.Must(t, "failed to create the token", err)
 
@@ -120,11 +120,12 @@ func TestAPIServer(t *testing.T) {
 				func(t *testing.T, ch chan message.Message) {
 					msg := <-ch
 					stubs.AssertEquals(t, "echo something", msg.GetText())
-					stubs.AssertEquals(t, "<#generalID>", msg.GetChannel())
 					stubs.AssertEquals(t, "generalID", msg.GetChannelID())
+					stubs.AssertEquals(t, "name: generalID", msg.GetChannel())
 					stubs.AssertEquals(t, "<#generalID>", msg.GetChannelLink())
-					stubs.AssertEquals(t, "<@someone>", msg.GetUsername())
-					stubs.AssertEquals(t, "someone", msg.GetUsernameID())
+					stubs.AssertEquals(t, "name: someone", msg.GetUsername())
+					stubs.AssertEquals(t, "<@someone>", msg.GetUserLink())
+					stubs.AssertEquals(t, "someone", msg.GetUserID())
 					stubs.AssertEquals(t, false, msg.IsIM())
 				},
 			},

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,53 +1,127 @@
 package api_test
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/pcarranza/meeseeks-box/api"
+	"github.com/pcarranza/meeseeks-box/meeseeks/message"
+	"github.com/pcarranza/meeseeks-box/tokens"
+
+	/*
+	   # API
+
+	   ## Will need
+
+	   * a token that links to a user+command+channel
+	   * a command to create a token
+	   * a command to revoke a token
+	   * a command to list tokens with commands
+
+	   ## Steps to enable the API
+
+	   1. Configuration: the endpoint in which to listen, namely address and path.
+	   2. Enabling: using a command, pass in the command that the API will be
+	   calling and the channel in which to reply, else it will be considered as an
+	   IM
+	   3. The command will need to resolve the channel <token> (the client will need to provide this)
+	   4. This command can only be called over IM
+	   5. ~The api enabling will need to test that the user has access to the requested command?~ (nah... late binding)
+
+	   ## Token data model
+
+	   - Tokens
+	     - Token (something something UUID hash)
+	       - UserID
+	       - ChannelID
+	       - Command
+	       - Args
+
+	   ### Interface
+
+	   - Create{payload} - returns the token
+	   - Get{Token}
+	   - List{UserID}
+
+	   # Steps to build:
+
+	   1. Create the data model
+	   2. Add the creation and the Get methods
+	   3. Add the http interface to post the token, return 200 when found
+	   4. Pipe the message to the stub client, check it works
+	   5. Finish implementation
+
+	*/
+
+	stubs "github.com/pcarranza/meeseeks-box/testingstubs"
 )
 
-/*
-# API
+func TestSendingCommand(t *testing.T) {
+	stubs.Must(t, "failed to create a temporary DB", stubs.WithTmpDB(func(dbpath string) {
+		// This is necessary because we need to store and then load the token in the DB
+		stubs.NewHarness().WithEchoCommand().WithDBPath(dbpath).Load()
 
-## Will need
+		tk, err := tokens.Create(tokens.NewTokenRequest{
+			User:    "someone",
+			Text:    "echo something",
+			Channel: "generalID",
+		})
+		stubs.Must(t, "failed to create the token", err)
 
-* a token that links to a user+command+channel
-* a command to create a token
-* a command to revoke a token
-* a command to list tokens with commands
+		s := api.NewServer(stubs.MetadataStub{
+			IM: false,
+		})
 
-## Steps to enable the API
+		ch := make(chan message.Message)
+		go s.ListenMessages(ch)
 
-1. Configuration: the endpoint in which to listen, namely address and path.
-2. Enabling: using a command, pass in the command that the API will be
-calling and the channel in which to reply, else it will be considered as an
-IM
-3. The command will need to resolve the channel <token> (the client will need to provide this)
-4. This command can only be called over IM
-5. ~The api enabling will need to test that the user has access to the requested command?~ (nah... late binding)
+		testSrv := httptest.NewServer(http.HandlerFunc(s.HandlePostToken))
 
-## Token data model
+		assertHttpStatus := func(statusCode int) func(t *testing.T, actualStatus string) {
+			return func(t *testing.T, actualStatus string) {
+				stubs.AssertEquals(t, fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+					actualStatus)
+			}
+		}
 
-- Tokens
-  - Token (something something UUID hash)
-    - UserID
-    - ChannelID
-    - Command
-    - Args
+		tt := []struct {
+			name          string
+			reqToken      string
+			assertStatus  func(*testing.T, string)
+			assertMessage func(*testing.T, message.Message)
+		}{
+			{
+				"valid call",
+				tk,
+				assertHttpStatus(http.StatusAccepted),
+				func(t *testing.T, msg message.Message) {
+					stubs.AssertEquals(t, "echo something", msg.GetText())
+					stubs.AssertEquals(t, "<#generalID>", msg.GetChannel())
+					stubs.AssertEquals(t, "generalID", msg.GetChannelID())
+					stubs.AssertEquals(t, "<@someone>", msg.GetUsername())
+					stubs.AssertEquals(t, "someone", msg.GetUsernameID())
+					stubs.AssertEquals(t, false, msg.IsIM())
+				},
+			},
+		}
+		for _, tc := range tt {
+			t.Run(tc.name, func(t *testing.T) {
+				req, err := http.NewRequest("POST", testSrv.URL, nil)
+				stubs.Must(t, "Could not create request", err)
 
-### Interface
+				req.Header.Add("TOKEN", tk)
 
-- Create{payload} - returns the token
-- Get{Token}
-- List{UserID}
+				resp, err := testSrv.Client().Do(req)
+				stubs.Must(t, "failed to do request", err)
 
-# Steps to build:
+				tc.assertStatus(t, resp.Status)
 
-1. Create the data model
-2. Add the creation and the Get methods
-3. Add the http interface to post the token, return 200 when found
-4. Pipe the message to the stub client, check it works
-5. Finish implementation
+				msg := <-ch
+				tc.assertMessage(t, msg)
+			})
+		}
 
-*/
-
-func TestSomething(t *testing.T) {
+	}))
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -590,9 +590,9 @@ func (n newAPITokenCommand) Execute(job jobs.Job) (string, error) {
 		return "", fmt.Errorf("not enough arguments passed in")
 	}
 	t, err := tokens.Create(tokens.NewTokenRequest{
-		UserID:    job.Request.UserID,
-		ChannelID: job.Request.Args[0],
-		Text:      strings.Join(job.Request.Args[1:], " "),
+		UserID:      job.Request.UserID,
+		ChannelLink: job.Request.Args[0],
+		Text:        strings.Join(job.Request.Args[1:], " "),
 	})
 	return fmt.Sprintf("created token %s", t), err
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pcarranza/meeseeks-box/jobs/logs"
 
 	"github.com/pcarranza/meeseeks-box/jobs"
-	"github.com/pcarranza/meeseeks-box/token"
+	"github.com/pcarranza/meeseeks-box/tokens"
 
 	"github.com/pcarranza/meeseeks-box/auth"
 	"github.com/pcarranza/meeseeks-box/command"
@@ -589,7 +589,7 @@ func (n newAPITokenCommand) Execute(job jobs.Job) (string, error) {
 	if len(job.Request.Args) < 2 {
 		return "", fmt.Errorf("not enough arguments passed in")
 	}
-	t, err := token.Create(token.NewTokenRequest{
+	t, err := tokens.Create(tokens.NewTokenRequest{
 		User:    job.Request.Username,
 		Channel: job.Request.Args[0],
 		Command: job.Request.Args[1],

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -40,33 +40,43 @@ var Commands = map[string]command.Command{
 	// map
 	BuiltinVersionCommand: versionCommand{
 		help: help{"prints the running meeseeks version"},
+		cmd:  cmd{BuiltinVersionCommand},
 	},
 	BuiltinGroupsCommand: groupsCommand{
 		help: help{"prints the configured groups"},
+		cmd:  cmd{BuiltinGroupsCommand},
 	},
 	BuiltinJobsCommand: jobsCommand{
 		help: help{"shows the last executed jobs for the calling user, accepts -limit"},
+		cmd:  cmd{BuiltinJobsCommand},
 	},
 	BuiltinAuditCommand: auditCommand{
 		help: help{"lists jobs from all users or a specific one (admin only), accepts -user and -limit to filter."},
+		cmd:  cmd{BuiltinAuditCommand},
 	},
 	BuiltinAuditJobCommand: auditJobCommand{
 		help: help{"shows a command metadata by job ID from any user (admin only)"},
+		cmd:  cmd{BuiltinAuditJobCommand},
 	},
 	BuiltinAuditLogsCommand: auditLogsCommand{
 		help: help{"shows the logs of any command by job ID (admin only)"},
+		cmd:  cmd{BuiltinAuditLogsCommand},
 	},
 	BuiltinLastCommand: lastCommand{
 		help: help{"shows the last executed command by the calling user"},
+		cmd:  cmd{BuiltinLastCommand},
 	},
 	BuiltinFindJobCommand: findJobCommand{
 		help: help{"find one job by id"},
+		cmd:  cmd{BuiltinFindJobCommand},
 	},
 	BuiltinTailCommand: tailCommand{
 		help: help{"returns the last command output or error"},
+		cmd:  cmd{BuiltinTailCommand},
 	},
 	BuiltinLogsCommand: logsCommand{
 		help: help{"returns the logs of the command id passed as argument"},
+		cmd:  cmd{BuiltinLogsCommand},
 	},
 }
 
@@ -74,6 +84,7 @@ var Commands = map[string]command.Command{
 func AddHelpCommand(c map[string]command.Command) {
 	c[BuiltinHelpCommand] = helpCommand{
 		commands: c,
+		cmd:      cmd{BuiltinHelpCommand},
 		help:     help{"prints all the kwnown commands and its associated help"},
 	}
 }
@@ -146,7 +157,16 @@ func (h help) Help() string {
 	return h.help
 }
 
+type cmd struct {
+	cmd string
+}
+
+func (c cmd) Cmd() string {
+	return c.cmd
+}
+
 type versionCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -156,16 +176,13 @@ type versionCommand struct {
 	defaultTimeout
 }
 
-func (v versionCommand) Cmd() string {
-	return BuiltinVersionCommand
-}
-
 func (v versionCommand) Execute(job jobs.Job) (string, error) {
 	return fmt.Sprintf("meeseeks-box version %s, commit %s, built at %s",
 		version.Version, version.Commit, version.Date), nil
 }
 
 type helpCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -180,10 +197,6 @@ var helpTemplate = dedent.Dedent(`
 	{{ range $name, $cmd := .commands }}- {{ $name }}: {{ $cmd.Help }}
 	{{ end }}`)
 
-func (h helpCommand) Cmd() string {
-	return BuiltinHelpCommand
-}
-
 func (h helpCommand) Execute(job jobs.Job) (string, error) {
 	tmpl, err := template.New("help", helpTemplate)
 	if err != nil {
@@ -195,6 +208,7 @@ func (h helpCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type groupsCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -211,10 +225,6 @@ var groupsTemplate = dedent.Dedent(`
 	{{- end }}
 	`)
 
-func (g groupsCommand) Cmd() string {
-	return BuiltinGroupsCommand
-}
-
 func (g groupsCommand) Execute(job jobs.Job) (string, error) {
 	tmpl, err := template.New("version", groupsTemplate)
 	if err != nil {
@@ -226,6 +236,7 @@ func (g groupsCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type jobsCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -248,10 +259,6 @@ var jobsTemplate = strings.Join([]string{
 	"{{ end }}",
 	"{{ end }}",
 }, "")
-
-func (j jobsCommand) Cmd() string {
-	return BuiltinJobsCommand
-}
 
 func (j jobsCommand) Execute(job jobs.Job) (string, error) {
 	flags := flag.NewFlagSet("jobs", flag.ContinueOnError)
@@ -284,6 +291,7 @@ func (j jobsCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type auditCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -291,10 +299,6 @@ type auditCommand struct {
 	plainTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (j auditCommand) Cmd() string {
-	return BuiltinAuditCommand
 }
 
 func (j auditCommand) Execute(job jobs.Job) (string, error) {
@@ -334,6 +338,7 @@ func (j auditCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type lastCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -352,10 +357,6 @@ var jobTemplate = `
 * *When* {{ HumanizeTime $job.StartTime }}
 {{- end }}{{- end }}
 `
-
-func (l lastCommand) Cmd() string {
-	return BuiltinLastCommand
-}
 
 func (l lastCommand) Execute(job jobs.Job) (string, error) {
 	callingUser := job.Request.Username
@@ -379,6 +380,7 @@ func (l lastCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type findJobCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -386,10 +388,6 @@ type findJobCommand struct {
 	plainTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (l findJobCommand) Cmd() string {
-	return BuiltinFindJobCommand
 }
 
 func (l findJobCommand) Execute(job jobs.Job) (string, error) {
@@ -422,6 +420,7 @@ func (l findJobCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type auditJobCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -429,10 +428,6 @@ type auditJobCommand struct {
 	plainTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (l auditJobCommand) Cmd() string {
-	return BuiltinAuditJobCommand
 }
 
 func (l auditJobCommand) Execute(job jobs.Job) (string, error) {
@@ -462,6 +457,7 @@ func (l auditJobCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type auditLogsCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -469,10 +465,6 @@ type auditLogsCommand struct {
 	defaultTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (t auditLogsCommand) Cmd() string {
-	return BuiltinAuditLogsCommand
 }
 
 func (t auditLogsCommand) Execute(job jobs.Job) (string, error) {
@@ -502,6 +494,7 @@ func (t auditLogsCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type tailCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -509,10 +502,6 @@ type tailCommand struct {
 	defaultTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (t tailCommand) Cmd() string {
-	return BuiltinTailCommand
 }
 
 func (t tailCommand) Execute(job jobs.Job) (string, error) {
@@ -537,6 +526,7 @@ func (t tailCommand) Execute(job jobs.Job) (string, error) {
 }
 
 type logsCommand struct {
+	cmd
 	help
 	noHandshake
 	noRecord
@@ -544,10 +534,6 @@ type logsCommand struct {
 	defaultTemplates
 	emptyArgs
 	defaultTimeout
-}
-
-func (t logsCommand) Cmd() string {
-	return BuiltinLogsCommand
 }
 
 func (t logsCommand) Execute(job jobs.Job) (string, error) {

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -586,13 +586,13 @@ func (n newAPITokenCommand) Execute(job jobs.Job) (string, error) {
 	if !job.Request.IsIM {
 		return "", fmt.Errorf("API tokens can only be created over an IM conversation, security ffs")
 	}
-	if len(job.Request.Args) < 2 {
+	if len(job.Request.Args) < 3 {
 		return "", fmt.Errorf("not enough arguments passed in")
 	}
 	t, err := tokens.Create(tokens.NewTokenRequest{
-		UserID:      job.Request.UserID,
-		ChannelLink: job.Request.Args[0],
-		Text:        strings.Join(job.Request.Args[1:], " "),
+		UserLink:    job.Request.Args[0],
+		ChannelLink: job.Request.Args[1],
+		Text:        strings.Join(job.Request.Args[2:], " "),
 	})
 	return fmt.Sprintf("created token %s", t), err
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -590,9 +590,9 @@ func (n newAPITokenCommand) Execute(job jobs.Job) (string, error) {
 		return "", fmt.Errorf("not enough arguments passed in")
 	}
 	t, err := tokens.Create(tokens.NewTokenRequest{
-		User:    job.Request.Username,
-		Channel: job.Request.Args[0],
-		Text:    strings.Join(job.Request.Args[1:], " "),
+		UserID:    job.Request.UserID,
+		ChannelID: job.Request.Args[0],
+		Text:      strings.Join(job.Request.Args[1:], " "),
 	})
 	return fmt.Sprintf("created token %s", t), err
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -592,8 +592,7 @@ func (n newAPITokenCommand) Execute(job jobs.Job) (string, error) {
 	t, err := tokens.Create(tokens.NewTokenRequest{
 		User:    job.Request.Username,
 		Channel: job.Request.Args[0],
-		Command: job.Request.Args[1],
-		Args:    job.Request.Args[2:],
+		Text:    strings.Join(job.Request.Args[1:], " "),
 	})
 	return fmt.Sprintf("created token %s", t), err
 }

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -576,7 +576,7 @@ type newAPITokenCommand struct {
 	help
 	noHandshake
 	noRecord
-	allowAll
+	allowAdmins
 	defaultTemplates
 	emptyArgs
 	defaultTimeout

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -60,6 +60,7 @@ func Test_BuiltinCommands(t *testing.T) {
 				- logs: returns the logs of the command id passed as argument
 				- tail: returns the last command output or error
 				- token-new: creates a new API token for the calling user, channel and command with args, requires at least #channel and command
+				- tokens: lists the API tokens
 				- version: prints the running meeseeks version
 				`),
 		},

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pcarranza/meeseeks-box/jobs/logs"
 	"github.com/pcarranza/meeseeks-box/meeseeks/request"
 	stubs "github.com/pcarranza/meeseeks-box/testingstubs"
+	"github.com/pcarranza/meeseeks-box/tokens"
 	"github.com/renstrom/dedent"
 )
 
@@ -60,6 +61,7 @@ func Test_BuiltinCommands(t *testing.T) {
 				- logs: returns the logs of the command id passed as argument
 				- tail: returns the last command output or error
 				- token-new: creates a new API token for the calling user, channel and command with args, requires at least #channel and command
+				- token-revoke: revokes an API token
 				- tokens: lists the API tokens
 				- version: prints the running meeseeks version
 				`),
@@ -224,6 +226,23 @@ func Test_BuiltinCommands(t *testing.T) {
 				Request: request.Request{Username: "admin_user", IsIM: true, Args: []string{"admin_user", "yolo", "rm", "-rf"}},
 			},
 			expectedMatch: "created token .*",
+		},
+		{
+			name: "test tokens command",
+			cmd:  builtins.BuiltinListAPITokenCommand,
+			job: jobs.Job{
+				Request: request.Request{Username: "admin_user", IsIM: true},
+			},
+			setup: func() {
+				_, err := tokens.Create(tokens.NewTokenRequest{
+					ChannelLink: "channelLink",
+					UserLink:    "userLink",
+					Text:        "something",
+				})
+				stubs.Must(t, "create token", err)
+
+			},
+			expectedMatch: "- \\*.*?\\* userLink at channelLink _something_",
 		},
 	}
 

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -220,7 +220,7 @@ func Test_BuiltinCommands(t *testing.T) {
 			name: "test token-new command",
 			cmd:  builtins.BuiltinNewAPITokenCommand,
 			job: jobs.Job{
-				Request: request.Request{Username: "admin_user", IsIM: true, Args: []string{"yolo", "rm", "-rf"}},
+				Request: request.Request{Username: "admin_user", IsIM: true, Args: []string{"admin_user", "yolo", "rm", "-rf"}},
 			},
 			expectedMatch: "created token .*",
 		},

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -218,7 +218,7 @@ func Test_BuiltinCommands(t *testing.T) {
 
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			stubs.Must(t, "failed to run tests", stubs.WithTmpDB(func() {
+			stubs.Must(t, "failed to run tests", stubs.WithTmpDB(func(_ string) {
 				if tc.setup != nil {
 					tc.setup()
 				}
@@ -236,7 +236,7 @@ func Test_BuiltinCommands(t *testing.T) {
 }
 
 func Test_FilterJobsAudit(t *testing.T) {
-	stubs.Must(t, "failed to audit the correct jobs", stubs.WithTmpDB(func() {
+	stubs.Must(t, "failed to audit the correct jobs", stubs.WithTmpDB(func(_ string) {
 		r1 := request.Request{
 			Command:     "command",
 			Channel:     "general",

--- a/commands/shell/shell_test.go
+++ b/commands/shell/shell_test.go
@@ -32,7 +32,7 @@ func TestShellCommand(t *testing.T) {
 }
 
 func TestExecuteEcho(t *testing.T) {
-	stubs.WithTmpDB(func() {
+	stubs.WithTmpDB(func(_ string) {
 		out, err := echoCommand.Execute(jobs.Job{
 			ID:      1,
 			Request: request.Request{Args: []string{"hello", "meeseeks\nsecond line"}},
@@ -43,7 +43,7 @@ func TestExecuteEcho(t *testing.T) {
 }
 
 func TestExecuteFail(t *testing.T) {
-	stubs.WithTmpDB(func() {
+	stubs.WithTmpDB(func(_ string) {
 		_, err := failCommand.Execute(jobs.Job{
 			ID:      2,
 			Request: request.Request{},

--- a/db/db.go
+++ b/db/db.go
@@ -21,6 +21,10 @@ type DatabaseConfig struct {
 
 // Configure loads the required configuration to be able of connecting to a database
 func Configure(cnf DatabaseConfig) error {
+	if database != nil { // Close the database if it is currently open. This is probably candidate for a mutex
+		database.Close()
+	}
+
 	databaseConfig = cnf
 	db, err := open()
 	if err != nil {
@@ -92,4 +96,12 @@ func NextSequenceFor(bucketID []byte, tx *bolt.Tx) (uint64, *bolt.Bucket, error)
 		return 0, nil, err
 	}
 	return sequence, bucket, nil
+}
+
+// Close closes the database
+func Close() error {
+	if database == nil {
+		return nil
+	}
+	return database.Close()
 }

--- a/formatter/formatter.go
+++ b/formatter/formatter.go
@@ -1,0 +1,39 @@
+package formatter
+
+import (
+	"github.com/pcarranza/meeseeks-box/config"
+	"github.com/pcarranza/meeseeks-box/template"
+)
+
+type Formatter struct {
+	colors    config.MessageColors
+	templates *template.TemplatesBuilder
+}
+
+func New(cnf config.Config) *Formatter {
+	builder := template.NewBuilder().WithMessages(cnf.Messages)
+	return &Formatter{
+		colors:    cnf.Colors,
+		templates: builder,
+	}
+}
+
+func (f Formatter) ErrorColor() string {
+	return f.colors.Error
+}
+
+func (f Formatter) InfoColor() string {
+	return f.colors.Info
+}
+
+func (f Formatter) SuccessColor() string {
+	return f.colors.Success
+}
+
+func (f Formatter) Templates() template.Templates {
+	return f.templates.Clone().Build()
+}
+
+func (f Formatter) WithTemplates(templates map[string]string) template.Templates {
+	return f.templates.Clone().WithTemplates(templates).Build()
+}

--- a/jobs/jobs.go
+++ b/jobs/jobs.go
@@ -56,7 +56,7 @@ func Create(req request.Request) (Job, error) {
 			Status:    RunningStatus,
 		}
 
-		log.Debugf("creating job $#v", job)
+		log.Debugf("Creating job %#v", job)
 		return save(job, bucket)
 	})
 	if err != nil {
@@ -79,6 +79,7 @@ func Get(id uint64) (Job, error) {
 		}
 		return json.Unmarshal(payload, job)
 	})
+	log.Debugf("Returning job %#v for ID %d, err: %s", *job, id, err)
 	return *job, err
 }
 

--- a/jobs/jobs_test.go
+++ b/jobs/jobs_test.go
@@ -15,14 +15,14 @@ var req = request.Request{
 }
 
 func Test_GettingAJobWorksWhenEmpty(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		_, err := jobs.Get(1)
 		stub.AssertEquals(t, "no job could be found", err.Error())
 	}))
 }
 
 func Test_GettingJobsWorksWhenEmpty(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		js, err := jobs.Find(jobs.JobFilter{
 			Limit: 10,
 			Match: func(_ jobs.Job) bool {
@@ -35,7 +35,7 @@ func Test_GettingJobsWorksWhenEmpty(t *testing.T) {
 }
 
 func Test_CreatingAndThenGettingAJob(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		expected, err := jobs.Create(req)
 		stub.Must(t, "Could not store a job: ", err)
 
@@ -47,7 +47,7 @@ func Test_CreatingAndThenGettingAJob(t *testing.T) {
 }
 
 func Test_MarkSuccessFul(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		job, err := jobs.Create(req)
 		stub.Must(t, "Could not store a job: ", err)
 
@@ -65,7 +65,7 @@ func Test_MarkSuccessFul(t *testing.T) {
 }
 
 func Test_MarkSuccessFulWithRunningEndStateFails(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		job, err := jobs.Create(req)
 		stub.Must(t, "Could not store a job: ", err)
 
@@ -77,7 +77,7 @@ func Test_MarkSuccessFulWithRunningEndStateFails(t *testing.T) {
 }
 
 func Test_FilterReturnsInOrder(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		jobs.Create(req)
 		jobs.Create(req)
 		jobs.Create(req)
@@ -93,7 +93,7 @@ func Test_FilterReturnsInOrder(t *testing.T) {
 }
 
 func Test_FilterReturnsEnough(t *testing.T) {
-	stub.Must(t, "failed to run tests", stub.WithTmpDB(func() {
+	stub.Must(t, "failed to run tests", stub.WithTmpDB(func(_ string) {
 		jobs.Create(req)
 		jobs.Create(req)
 

--- a/jobs/logs/logs_test.go
+++ b/jobs/logs/logs_test.go
@@ -45,7 +45,7 @@ func Test_Logs(t *testing.T) {
 			},
 		},
 	}
-	stubs.WithTmpDB(func() {
+	stubs.WithTmpDB(func(_ string) {
 		for _, tc := range tt {
 			t.Run(tc.name, func(t *testing.T) {
 				for _, line := range tc.logs {
@@ -64,14 +64,14 @@ func Test_Logs(t *testing.T) {
 }
 
 func Test_GetLoglessJob(t *testing.T) {
-	stubs.WithTmpDB(func() {
+	stubs.WithTmpDB(func(_ string) {
 		_, err := logs.Get(1)
 		stubs.AssertEquals(t, logs.ErrNoLogsForJob, err)
 	})
 }
 
 func Test_ErredOutJobHasError(t *testing.T) {
-	stubs.WithTmpDB(func() {
+	stubs.WithTmpDB(func(_ string) {
 		logs.SetError(1, errors.New("nasty error"))
 		l, err := logs.Get(1)
 		stubs.Must(t, "should be able to get a job with only an error", err)

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	}
 
 	meeseek := meeseeks.New(messaging, cnf)
-	go meeseek.Start(messaging.MessagesCh)
+	go meeseek.Start()
 
 	signalCh := make(chan os.Signal)
 	signal.Notify(signalCh, syscall.SIGINT, syscall.SIGTERM)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 func main() {
 	configFile := flag.String("config", os.ExpandEnv("${HOME}/.meeseeks.yaml"), "meeseeks configuration file")
 	debugMode := flag.Bool("debug", false, "enabled debug mode")
+	debugSlack := flag.Bool("debug-slack", false, "enabled debug mode for slack")
 	showVersion := flag.Bool("version", false, "print the version and exit")
 	apiAddress := flag.String("api-endpoint", ":9696", "api endpoint in which to listen for api calls")
 	apiPath := flag.String("api-path", "/message", "api path in to listen for api calls")
@@ -46,7 +47,7 @@ func main() {
 
 	log.Info("Loaded configuration")
 
-	slackClient, err := slack.Connect(*debugMode, os.Getenv("SLACK_TOKEN"))
+	slackClient, err := slack.Connect(*debugSlack, os.Getenv("SLACK_TOKEN"))
 	if err != nil {
 		log.Fatalf("Could not connect to slack: %s", err)
 	}

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 
 	"github.com/pcarranza/meeseeks-box/command"
 	"github.com/pcarranza/meeseeks-box/formatter"
 	"github.com/pcarranza/meeseeks-box/jobs"
 	"github.com/pcarranza/meeseeks-box/messenger"
-	log "github.com/sirupsen/logrus"
 
 	"github.com/pcarranza/meeseeks-box/auth"
 	"github.com/pcarranza/meeseeks-box/commands"
@@ -59,7 +59,7 @@ func (m *Meeseeks) Start() {
 	for msg := range m.messenger.MessagesCh() {
 		req, err := request.FromMessage(msg)
 		if err != nil {
-			log.Debugf("Failed to parse message '%s' as a command: %s", msg.GetText(), err)
+			logrus.Debugf("Failed to parse message '%s' as a command: %s", msg.GetText(), err)
 			m.replyWithError(msg, err)
 			continue
 		}
@@ -74,7 +74,7 @@ func (m *Meeseeks) Start() {
 			continue
 		}
 
-		log.Infof("Accepted command '%s' from user '%s' on channel '%s' with args: %s",
+		logrus.Infof("Accepted command '%s' from user '%s' on channel '%s' with args: %s",
 			req.Command, req.Username, req.Channel, req.Args)
 
 		t, err := m.createTask(req, cmd)
@@ -102,9 +102,9 @@ func (m *Meeseeks) createTask(req request.Request, cmd command.Command) (task, e
 func (m *Meeseeks) Shutdown() {
 	defer m.closeTasksChannel()
 
-	log.Info("Waiting for jobs to finish")
+	logrus.Info("Waiting for jobs to finish")
 	m.wg.Wait()
-	log.Info("Done waiting, exiting")
+	logrus.Info("Done waiting, exiting")
 }
 
 func (m *Meeseeks) closeTasksChannel() {
@@ -123,7 +123,7 @@ func (m *Meeseeks) jobsLoop() {
 
 			out, err := t.cmd.Execute(t.job)
 			if err != nil {
-				log.Errorf("Command '%s' from user '%s' failed execution with error: %s",
+				logrus.Errorf("Command '%s' from user '%s' failed execution with error: %s",
 					req.Command, req.Username, err)
 				m.replyWithCommandFailed(req, cmd, err, out)
 				job.Finish(jobs.FailedStatus)

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -20,6 +20,7 @@ import (
 type Client interface {
 	Reply(text, color, channel string) error
 	ReplyIM(text, color, user string) error
+	MessagesCh() chan message.Message
 }
 
 // Meeseeks is the command execution engine
@@ -56,8 +57,8 @@ func New(client Client, conf config.Config) *Meeseeks {
 }
 
 // Start launches the meeseeks to read messages from the MessageCh
-func (m *Meeseeks) Start(messageCh chan message.Message) {
-	for msg := range messageCh {
+func (m *Meeseeks) Start() {
+	for msg := range m.client.MessagesCh() {
 		req, err := request.FromMessage(msg)
 		if err != nil {
 			log.Debugf("Failed to parse message '%s' as a command: %s", msg.GetText(), err)

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/prometheus/common/log"
 	"github.com/sirupsen/logrus"
 
 	"github.com/pcarranza/meeseeks-box/command"
@@ -128,7 +127,7 @@ func (m *Meeseeks) jobsLoop() {
 				m.replyWithCommandFailed(req, cmd, err, out)
 				job.Finish(jobs.FailedStatus)
 			} else {
-				log.Infof("Command '%s' from user '%s' succeeded execution", req.Command,
+				logrus.Infof("Command '%s' from user '%s' succeeded execution", req.Command,
 					req.Username)
 				m.replyWithSuccess(job.Request, cmd, out)
 				job.Finish(jobs.SuccessStatus)

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/pcarranza/meeseeks-box/command"
 	"github.com/pcarranza/meeseeks-box/formatter"
 	"github.com/pcarranza/meeseeks-box/jobs"
@@ -98,11 +100,16 @@ func (m *Meeseeks) createTask(req request.Request, cmd command.Command) (task, e
 // Shutdown initiates a shutdown process by waiting for jobs to finish and then
 // closing the tasks channel
 func (m *Meeseeks) Shutdown() {
-	defer close(m.tasksCh)
+	defer m.closeTasksChannel()
 
 	log.Info("Waiting for jobs to finish")
 	m.wg.Wait()
 	log.Info("Done waiting, exiting")
+}
+
+func (m *Meeseeks) closeTasksChannel() {
+	logrus.Infof("Closing meeseeks tasks channel")
+	close(m.tasksCh)
 }
 
 func (m *Meeseeks) jobsLoop() {

--- a/meeseeks/meeseeks_test.go
+++ b/meeseeks/meeseeks_test.go
@@ -5,6 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pcarranza/meeseeks-box/messenger"
+
+	"github.com/pcarranza/meeseeks-box/formatter"
+
 	"github.com/renstrom/dedent"
 
 	"regexp"
@@ -147,7 +151,11 @@ func Test_MeeseeksInteractions(t *testing.T) {
 			    args: ["pre-message"]
 			`)).WithDBPath(dbpath).Load()
 
-		m := meeseeks.New(client, cnf)
+		msgs, err := messenger.Listen(client)
+		if err != nil {
+			t.Fatalf("could not create listener: %s", err)
+		}
+		m := meeseeks.New(client, msgs, formatter.New(cnf))
 		go m.Start()
 
 		for _, tc := range tt {

--- a/meeseeks/message/message.go
+++ b/meeseeks/message/message.go
@@ -13,7 +13,9 @@ type Message interface {
 	// The friendly name of the user that has sent the message, used internally to match with groups and such
 	GetUsername() string
 	// The username id of the user that has sent the message, used in replies so they notify the user
-	GetUsernameID() string
+	GetUserID() string
+	// The user link returns a link to the user
+	GetUserLink() string
 	// IsIM
 	IsIM() bool
 }

--- a/meeseeks/replies.go
+++ b/meeseeks/replies.go
@@ -8,7 +8,7 @@ import (
 )
 
 func (m *Meeseeks) replyWithError(msg message.Message, err error) {
-	content, err := m.formatter.Templates().RenderFailure(msg.GetUsernameID(), err.Error(), "")
+	content, err := m.formatter.Templates().RenderFailure(msg.GetUserLink(), err.Error(), "")
 	if err != nil {
 		log.Fatalf("could not render failure template: %s", err)
 	}
@@ -21,7 +21,7 @@ func (m *Meeseeks) replyWithError(msg message.Message, err error) {
 func (m *Meeseeks) replyWithUnknownCommand(req request.Request) {
 	log.Debugf("Could not find command '%s' in the command registry", req.Command)
 
-	msg, err := m.formatter.Templates().RenderUnknownCommand(req.UsernameID, req.Command)
+	msg, err := m.formatter.Templates().RenderUnknownCommand(req.UserLink, req.Command)
 	if err != nil {
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
@@ -35,7 +35,7 @@ func (m *Meeseeks) replyWithHandshake(req request.Request, cmd command.Command) 
 	if !cmd.HasHandshake() {
 		return
 	}
-	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderHandshake(req.UsernameID)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderHandshake(req.UserLink)
 	if err != nil {
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
@@ -49,7 +49,7 @@ func (m *Meeseeks) replyWithUnauthorizedCommand(req request.Request, cmd command
 	log.Debugf("User %s is not allowed to run command '%s' on channel '%s'", req.Username,
 		req.Command, req.Channel)
 
-	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderUnauthorizedCommand(req.UsernameID, req.Command)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderUnauthorizedCommand(req.UserLink, req.Command)
 	if err != nil {
 		log.Fatalf("could not render unathorized command template %s", err)
 	}
@@ -60,7 +60,7 @@ func (m *Meeseeks) replyWithUnauthorizedCommand(req request.Request, cmd command
 }
 
 func (m *Meeseeks) replyWithCommandFailed(req request.Request, cmd command.Command, err error, out string) {
-	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderFailure(req.UsernameID, err.Error(), out)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderFailure(req.UserLink, err.Error(), out)
 	if err != nil {
 		log.Fatalf("could not render failure template %s", err)
 	}
@@ -71,7 +71,7 @@ func (m *Meeseeks) replyWithCommandFailed(req request.Request, cmd command.Comma
 }
 
 func (m *Meeseeks) replyWithSuccess(req request.Request, cmd command.Command, out string) {
-	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderSuccess(req.UsernameID, out)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderSuccess(req.UserLink, out)
 
 	if err != nil {
 		log.Fatalf("could not render success template %s", err)

--- a/meeseeks/replies.go
+++ b/meeseeks/replies.go
@@ -4,17 +4,16 @@ import (
 	"github.com/pcarranza/meeseeks-box/command"
 	"github.com/pcarranza/meeseeks-box/meeseeks/message"
 	"github.com/pcarranza/meeseeks-box/meeseeks/request"
-	"github.com/pcarranza/meeseeks-box/template"
 	log "github.com/sirupsen/logrus"
 )
 
 func (m *Meeseeks) replyWithError(msg message.Message, err error) {
-	content, err := m.templates.Build().RenderFailure(msg.GetUsernameID(), err.Error(), "")
+	content, err := m.formatter.Templates().RenderFailure(msg.GetUsernameID(), err.Error(), "")
 	if err != nil {
 		log.Fatalf("could not render failure template: %s", err)
 	}
 
-	if err = m.client.Reply(content, m.config.Colors.Error, msg.GetChannelID()); err != nil {
+	if err = m.client.Reply(content, m.formatter.ErrorColor(), msg.GetChannelID()); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -22,12 +21,12 @@ func (m *Meeseeks) replyWithError(msg message.Message, err error) {
 func (m *Meeseeks) replyWithUnknownCommand(req request.Request) {
 	log.Debugf("Could not find command '%s' in the command registry", req.Command)
 
-	msg, err := m.templates.Build().RenderUnknownCommand(req.UsernameID, req.Command)
+	msg, err := m.formatter.Templates().RenderUnknownCommand(req.UsernameID, req.Command)
 	if err != nil {
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.config.Colors.Error, req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -36,12 +35,12 @@ func (m *Meeseeks) replyWithHandshake(req request.Request, cmd command.Command) 
 	if !cmd.HasHandshake() {
 		return
 	}
-	msg, err := m.buildTemplatesFor(cmd).RenderHandshake(req.UsernameID)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderHandshake(req.UsernameID)
 	if err != nil {
 		log.Fatalf("could not render unknown command template: %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.config.Colors.Info, req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, m.formatter.InfoColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
@@ -50,39 +49,35 @@ func (m *Meeseeks) replyWithUnauthorizedCommand(req request.Request, cmd command
 	log.Debugf("User %s is not allowed to run command '%s' on channel '%s'", req.Username,
 		req.Command, req.Channel)
 
-	msg, err := m.buildTemplatesFor(cmd).RenderUnauthorizedCommand(req.UsernameID, req.Command)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderUnauthorizedCommand(req.UsernameID, req.Command)
 	if err != nil {
 		log.Fatalf("could not render unathorized command template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.config.Colors.Error, req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
 
 func (m *Meeseeks) replyWithCommandFailed(req request.Request, cmd command.Command, err error, out string) {
-	msg, err := m.buildTemplatesFor(cmd).RenderFailure(req.UsernameID, err.Error(), out)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderFailure(req.UsernameID, err.Error(), out)
 	if err != nil {
 		log.Fatalf("could not render failure template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.config.Colors.Error, req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, m.formatter.ErrorColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
 }
 
 func (m *Meeseeks) replyWithSuccess(req request.Request, cmd command.Command, out string) {
-	msg, err := m.buildTemplatesFor(cmd).RenderSuccess(req.UsernameID, out)
+	msg, err := m.formatter.WithTemplates(cmd.Templates()).RenderSuccess(req.UsernameID, out)
 
 	if err != nil {
 		log.Fatalf("could not render success template %s", err)
 	}
 
-	if err = m.client.Reply(msg, m.config.Colors.Success, req.ChannelID); err != nil {
+	if err = m.client.Reply(msg, m.formatter.SuccessColor(), req.ChannelID); err != nil {
 		log.Errorf("Failed to reply: %s", err)
 	}
-}
-
-func (m *Meeseeks) buildTemplatesFor(cmd command.Command) template.Templates {
-	return m.templates.Clone().WithTemplates(cmd.Templates()).Build()
 }

--- a/meeseeks/request/parser/parser.go
+++ b/meeseeks/request/parser/parser.go
@@ -14,7 +14,7 @@ const (
 // ErrUnclosedQuoteInCommand means that the command is not correctly escaped
 var ErrUnclosedQuoteInCommand = errors.New("Unclosed quote on command")
 
-// ParseCommand parses a command and returns a slice of strings and an error if the command is wrongly built
+// Parse parses a command and returns a slice of strings and an error if the command is wrongly built
 func Parse(command string) ([]string, error) {
 	args := make([]string, 0)
 	state := startState
@@ -49,7 +49,7 @@ func Parse(command string) ([]string, error) {
 			continue
 		}
 
-		if c == '"' || c == '\'' {
+		if c == '"' || c == '\'' || c == '`' {
 			state = quotesState
 			quote = string(c)
 			continue

--- a/meeseeks/request/parser/parser_test.go
+++ b/meeseeks/request/parser/parser_test.go
@@ -38,6 +38,11 @@ func Test_ParsingCommandsCorrectly(t *testing.T) {
 			command:  "echo -n    'this is a message'",
 			expected: []string{"echo", "-n", "this is a message"},
 		},
+		{
+			name:     "with backticks",
+			command:  "echo `this is a message`",
+			expected: []string{"echo", "this is a message"},
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {

--- a/meeseeks/request/request.go
+++ b/meeseeks/request/request.go
@@ -15,7 +15,8 @@ type Request struct {
 	Command     string   `json:"Command"`
 	Args        []string `json:"Arguments"`
 	Username    string   `json:"Username"`
-	UsernameID  string   `json:"UsernameID"`
+	UserID      string   `json:"UserID"`
+	UserLink    string   `json:"UserLink"`
 	Channel     string   `json:"Channel"`
 	ChannelID   string   `json:"CannelID"`
 	ChannelLink string   `json:"CannelLink"`
@@ -37,7 +38,8 @@ func FromMessage(msg message.Message) (Request, error) {
 		Command:     args[0],
 		Args:        args[1:],
 		Username:    msg.GetUsername(),
-		UsernameID:  msg.GetUsernameID(),
+		UserID:      msg.GetUserID(),
+		UserLink:    msg.GetUserLink(),
 		Channel:     msg.GetChannel(),
 		ChannelID:   msg.GetChannelID(),
 		ChannelLink: msg.GetChannelLink(),

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -15,9 +15,12 @@ type Messenger struct {
 }
 
 // Listen starts a routine to listen for messages on the provided client
-func Listen(listener Listener) (*Messenger, error) {
+func Listen(listeners ...Listener) (*Messenger, error) {
 	messagesCh := make(chan message.Message)
-	go listener.ListenMessages(messagesCh)
+
+	for _, listener := range listeners {
+		go listener.ListenMessages(messagesCh)
+	}
 
 	return &Messenger{
 		messagesCh: messagesCh,

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -10,7 +10,7 @@ import (
 // Messenger handles multiple message sources
 type Messenger struct {
 	*slack.Client
-	MessagesCh chan message.Message
+	messagesCh chan message.Message
 }
 
 type MessengerOpts struct {
@@ -29,10 +29,14 @@ func Listen(opts MessengerOpts) (*Messenger, error) {
 
 	return &Messenger{
 		Client:     client,
-		MessagesCh: slackMessagesCh,
+		messagesCh: slackMessagesCh,
 	}, nil
 }
 
+func (m *Messenger) MessagesCh() chan message.Message {
+	return m.messagesCh
+}
+
 func (m *Messenger) Shutdown() {
-	close(m.MessagesCh)
+	close(m.messagesCh)
 }

--- a/messenger/messenger.go
+++ b/messenger/messenger.go
@@ -2,6 +2,7 @@ package messenger
 
 import (
 	"github.com/pcarranza/meeseeks-box/meeseeks/message"
+	"github.com/sirupsen/logrus"
 )
 
 // Listener provides the necessary interface to start listening messages in a channel.
@@ -34,5 +35,6 @@ func (m *Messenger) MessagesCh() <-chan message.Message {
 
 // Shutdown takes down the system
 func (m *Messenger) Shutdown() {
+	logrus.Infof("Shutting down messenger messages channel")
 	close(m.messagesCh)
 }

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -3,6 +3,7 @@ package slack
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -22,6 +23,19 @@ type Client struct {
 	// through a channel
 	rtm     *slack.RTM
 	matcher messageMatcher
+}
+
+// ParseChannelLink implements the messenger.MessengerClient interface
+func (c Client) ParseChannelLink(channel string) (string, error) {
+	r, err := regexp.Compile("<@(.*)\\|.*>")
+	if err != nil {
+		return "", fmt.Errorf("could not compile regex for parsing the channel link: %s", err)
+	}
+	mm := r.FindStringSubmatch(channel)
+	if len(mm) != 2 {
+		return "", fmt.Errorf("invalid channel link: %s", channel)
+	}
+	return mm[1], nil
 }
 
 // GetUsername implements the messenger.MessengerClient interface

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -149,16 +149,16 @@ func (m *messageMatcher) isMyself(message *slack.MessageEvent) bool {
 
 func (m *messageMatcher) shouldCare(message *slack.MessageEvent) (string, bool) {
 	if m.isMyself(message) {
-		logrus.Infof("It's myself, ignoring message")
+		logrus.Debug("It's myself, ignoring message")
 		return "", false
 	}
 	if m.isIMChannel(message.Channel) {
-		logrus.Infof("Channel %s is IM channel, responding...", message.Channel)
+		logrus.Debugf("Channel %s is IM channel, responding...", message.Channel)
 		return message.Text, true
 	}
 	for _, match := range m.prefixMatches {
 		if strings.HasPrefix(message.Text, match) {
-			logrus.Infof("Message %s matches prefix, responding...", message.Text)
+			logrus.Debugf("Message '%s' matches prefix, responding...", message.Text)
 			return strings.TrimSpace(message.Text[len(match):]), true
 		}
 	}
@@ -167,7 +167,7 @@ func (m *messageMatcher) shouldCare(message *slack.MessageEvent) (string, bool) 
 
 // ListenMessages listens to messages and sends the matching ones through the channel
 func (c *Client) ListenMessages(ch chan<- message.Message) {
-	logrus.Infof("Listening messages")
+	logrus.Infof("Listening Slack RTM Messages")
 
 	for msg := range c.rtm.IncomingEvents {
 		switch ev := msg.Data.(type) {
@@ -177,7 +177,7 @@ func (c *Client) ListenMessages(ch chan<- message.Message) {
 				continue
 			}
 
-			logrus.Debugf("Received matching message %#v", ev.Text)
+			logrus.Debugf("Received matching message '%s'", ev.Text)
 
 			ch <- *message
 

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -27,7 +27,7 @@ type Client struct {
 
 // ParseChannelLink implements the messenger.MessengerClient interface
 func (c Client) ParseChannelLink(channel string) (string, error) {
-	r, err := regexp.Compile("<@(.*)\\|.*>")
+	r, err := regexp.Compile("<#(.*)\\|.*>")
 	if err != nil {
 		return "", fmt.Errorf("could not compile regex for parsing the channel link: %s", err)
 	}

--- a/slack/slack.go
+++ b/slack/slack.go
@@ -38,6 +38,19 @@ func (c Client) ParseChannelLink(channel string) (string, error) {
 	return mm[1], nil
 }
 
+// ParseUserLink implements the messenger.MessengerClient interface
+func (c Client) ParseUserLink(userLink string) (string, error) {
+	r, err := regexp.Compile("<@(.*)>")
+	if err != nil {
+		return "", fmt.Errorf("could not compile regex for parsing the user link: %s", err)
+	}
+	mm := r.FindStringSubmatch(userLink)
+	if len(mm) != 2 {
+		return "", fmt.Errorf("invalid user link: %s", userLink)
+	}
+	return mm[1], nil
+}
+
 // GetUsername implements the messenger.MessengerClient interface
 func (c Client) GetUsername(userID string) string {
 	return c.matcher.getUser(userID)

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -47,13 +47,25 @@ func (h Harness) WithConfigFile(f string) Harness {
 	return h
 }
 
+// WithEchoCommand returns a harness configured to have an echo command available
+func (h Harness) WithEchoCommand() Harness {
+	h.cnf = `---
+commands:
+  echo:
+    command: echo
+    auth_strategy: any
+    timeout: 5
+`
+	return h
+}
+
 // WithConfig allows to change the configuration string
 func (h Harness) WithConfig(c string) Harness {
 	h.cnf = c
 	return h
 }
 
-// WithDB provides a dabatase filepath for the testing harness
+// WithDBPath provides a dabatase filepath for the testing harness
 func (h Harness) WithDBPath(dbpath string) Harness {
 	h.dbpath = dbpath
 	return h
@@ -208,4 +220,20 @@ func WithTmpDB(f func(dbpath string)) error {
 	f(dbpath)
 
 	return nil
+}
+
+type MetadataStub struct {
+	IM bool
+}
+
+func (m MetadataStub) GetChannel(channelID string) string {
+	return fmt.Sprintf("<#%s>", channelID)
+}
+
+func (m MetadataStub) GetUser(user string) string {
+	return fmt.Sprintf("<@%s>", user)
+}
+
+func (m MetadataStub) IsIM(_ string) bool {
+	return m.IM
 }

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -231,6 +231,10 @@ type MetadataStub struct {
 	IM bool
 }
 
+func (m MetadataStub) ParseChannelLink(channelLink string) (string, error) {
+	return channelLink, nil
+}
+
 func (m MetadataStub) GetChannelLink(channelID string) string {
 	return fmt.Sprintf("<#%s>", channelID)
 }

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -162,13 +162,18 @@ func (m MessageStub) GetChannelLink() string {
 	return m.Channel + "Link"
 }
 
-// GetUsernameID implements the slack.Message.GetUserFrom interface
-func (m MessageStub) GetUsernameID() string {
+// GetUserLink implements the slack.Message.GetUserFrom interface
+func (m MessageStub) GetUserLink() string {
 	return fmt.Sprintf("<@%s>", m.User)
 }
 
 // GetUsername implements the slack.Message.GetUsername interface
 func (m MessageStub) GetUsername() string {
+	return m.User
+}
+
+// GetUserID implements the slack.Message.GetUsername interface
+func (m MessageStub) GetUserID() string {
 	return m.User
 }
 
@@ -226,12 +231,28 @@ type MetadataStub struct {
 	IM bool
 }
 
-func (m MetadataStub) GetChannel(channelID string) string {
+func (m MetadataStub) GetChannelLink(channelID string) string {
 	return fmt.Sprintf("<#%s>", channelID)
 }
 
-func (m MetadataStub) GetUser(user string) string {
-	return fmt.Sprintf("<@%s>", user)
+func (m MetadataStub) GetChannelID(channelID string) string {
+	return channelID
+}
+
+func (m MetadataStub) GetChannel(channelID string) string {
+	return fmt.Sprintf("name: %s", channelID)
+}
+
+func (m MetadataStub) GetUserLink(userID string) string {
+	return fmt.Sprintf("<@%s>", userID)
+}
+
+func (m MetadataStub) GetUserID(userID string) string {
+	return userID
+}
+
+func (m MetadataStub) GetUsername(userID string) string {
+	return fmt.Sprintf("name: %s", userID)
 }
 
 func (m MetadataStub) IsIM(_ string) bool {

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -232,7 +232,11 @@ type MetadataStub struct {
 }
 
 func (m MetadataStub) ParseChannelLink(channelLink string) (string, error) {
-	return channelLink, nil
+	return strings.Replace(channelLink, "Link", "", -1), nil
+}
+
+func (m MetadataStub) ParseUserLink(userLink string) (string, error) {
+	return strings.Replace(userLink, "Link", "", -1), nil
 }
 
 func (m MetadataStub) GetChannelLink(channelID string) string {

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -113,6 +113,13 @@ func (c ClientStub) MessagesCh() chan message.Message {
 	return c.receivedMessages
 }
 
+// ListenMessages listens for messages and then passes it to the sent channel
+func (c ClientStub) ListenMessages(ch chan<- message.Message) {
+	for m := range c.receivedMessages {
+		ch <- m
+	}
+}
+
 // MessageStub is a simple stub that implements the Slack.Message interface
 type MessageStub struct {
 	Text      string

--- a/testingstubs/testingstubs.go
+++ b/testingstubs/testingstubs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path"
 	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -161,6 +162,15 @@ func (m MessageStub) IsIM() bool {
 func AssertEquals(t *testing.T, expected, actual interface{}) {
 	if !reflect.DeepEqual(expected, actual) {
 		t.Fatalf("Value is not as expected,\nexpected %#v;\ngot %#v", expected, actual)
+	}
+}
+
+// AssertMatches Helper function for asserting that a value is what we expect
+func AssertMatches(t *testing.T, expected, actual string) {
+	r, err := regexp.Compile(expected)
+	Must(t, fmt.Sprintf("regex %s does not compile", expected), err)
+	if !r.Match([]byte(actual)) {
+		t.Fatalf("Value does not match expected,\nexpected %#v;\ngot %#v", expected, actual)
 	}
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,137 @@
+package token
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/coreos/bbolt"
+	"github.com/pcarranza/meeseeks-box/db"
+)
+
+var tokensBucketKey = []byte("tokens")
+
+// ErrTokenNotFound is returned when a token can't be found given an ID
+var ErrTokenNotFound = fmt.Errorf("no token found")
+
+// NewTokenRequest is used to create a new token
+type NewTokenRequest struct {
+	User    string
+	Channel string
+	Command string
+	Args    []string
+}
+
+// Token is a persisted token
+type Token struct {
+	TokenID   string    `json:"token"`
+	User      string    `json:"user"`
+	Channel   string    `json:"channel"`
+	Command   string    `json:"command"`
+	Args      []string  `json:"args"`
+	CreatedOn time.Time `json:"created_on"`
+}
+
+// createUUID has been _honored_ from hashicorp UUID
+func createUUID() (string, error) {
+	buf := make([]byte, 16) // Maybe make this configurable
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%12x",
+		buf[0:4],
+		buf[4:6],
+		buf[6:8],
+		buf[8:10],
+		buf[10:16]), nil
+}
+
+// Create gets a new token request and creates a token persistence record. It returns the created token.
+func Create(r NewTokenRequest) (string, error) {
+	token, err := createUUID()
+	if err != nil {
+		return "", fmt.Errorf("could not create UUID for token: %s", err)
+	}
+
+	err = db.Update(func(tx *bolt.Tx) error {
+		bucket, err := tx.CreateBucketIfNotExists(tokensBucketKey)
+		if err != nil {
+			return err
+		}
+
+		t := Token{
+			TokenID:   token,
+			User:      r.User,
+			Channel:   r.Channel,
+			Command:   r.Command,
+			Args:      r.Args,
+			CreatedOn: time.Now(),
+		}
+		tb, err := json.Marshal(t)
+		if err != nil {
+			return fmt.Errorf("could not marshal token: %s", err)
+		}
+
+		return bucket.Put([]byte(token), tb)
+	})
+	return token, err
+}
+
+// Get returns the token given an ID, it may return ErrTokenNotFound when there is no such token
+func Get(tokenID string) (Token, error) {
+	var token Token
+	err := db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(tokensBucketKey)
+		if bucket == nil {
+			return ErrTokenNotFound
+		}
+
+		payload := bucket.Get([]byte(tokenID))
+		if payload == nil {
+			return ErrTokenNotFound
+		}
+
+		return json.Unmarshal(payload, &token)
+	})
+	return token, err
+}
+
+// Filter is used to filter the tokens to be returned from a List query
+type Filter struct {
+	Limit int
+	Match func(Token) bool
+}
+
+// Find returns a list of tokens that match the filter
+func Find(filter Filter) ([]Token, error) {
+	if filter.Match == nil {
+		filter.Match = func(_ Token) bool { return true }
+	}
+
+	tokens := make([]Token, 0)
+
+	err := db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(tokensBucketKey)
+		if bucket == nil {
+			return nil // an empty list is not an error
+		}
+
+		c := bucket.Cursor()
+		_, payload := c.First()
+		for len(tokens) < filter.Limit && payload != nil {
+
+			t := Token{}
+			if err := json.Unmarshal(payload, &t); err != nil {
+				return err
+			}
+
+			if filter.Match(t) {
+				tokens = append(tokens, t)
+			}
+			_, payload = c.Next()
+		}
+		return nil
+	})
+	return tokens, err
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,99 @@
+package token_test
+
+import (
+	"testing"
+
+	stubs "github.com/pcarranza/meeseeks-box/testingstubs"
+	"github.com/pcarranza/meeseeks-box/token"
+)
+
+func Test_TokenLifecycle(t *testing.T) {
+	stubs.WithTmpDB(func(_ string) {
+		id, err := token.Create(token.NewTokenRequest{
+			Command: "echo",
+			User:    "myuser",
+			Channel: "mychannel",
+			Args:    []string{"hello"},
+		})
+		stubs.Must(t, "could not create token", err)
+		if id == "" {
+			t.Fatal("create token returned an empty token id(?)")
+		}
+
+		tk, err := token.Get(id)
+		stubs.Must(t, "could not get token back", err)
+
+		stubs.AssertEquals(t, id, tk.TokenID)
+		stubs.AssertEquals(t, "echo", tk.Command)
+		stubs.AssertEquals(t, "myuser", tk.User)
+		stubs.AssertEquals(t, "mychannel", tk.Channel)
+		stubs.AssertEquals(t, []string{"hello"}, tk.Args)
+	})
+}
+
+func Test_TokenListing(t *testing.T) {
+	stubs.WithTmpDB(func(_ string) {
+		id, err := token.Create(token.NewTokenRequest{
+			Command: "echo",
+			User:    "myuser",
+			Channel: "mychannel",
+			Args:    []string{"hello"},
+		})
+		stubs.Must(t, "could not create token", err)
+
+		t1, err := token.Get(id)
+		stubs.Must(t, "could not get token back", err)
+
+		id, err = token.Create(token.NewTokenRequest{
+			Command: "echo",
+			User:    "someone_else",
+			Channel: "my_other_channel",
+			Args:    []string{"hello"},
+		})
+		stubs.Must(t, "could not create token", err)
+
+		t2, err := token.Get(id)
+		stubs.Must(t, "could not get token back", err)
+
+		tt := []struct {
+			Name     string
+			Filter   token.Filter
+			Expected []token.Token
+		}{
+			{
+				Name:     "empty list",
+				Expected: []token.Token{},
+				Filter: token.Filter{
+					Limit: 0,
+				},
+			},
+			{
+				Name:     "filter by username works",
+				Expected: []token.Token{t2},
+				Filter: token.Filter{
+					Limit: 5,
+					Match: func(tk token.Token) bool {
+						return tk.User == t2.User
+					},
+				},
+			},
+			{
+				Name:     "filter by channel works",
+				Expected: []token.Token{t1},
+				Filter: token.Filter{
+					Limit: 5,
+					Match: func(tk token.Token) bool {
+						return tk.Channel == t1.Channel
+					},
+				},
+			},
+		}
+		for _, tc := range tt {
+			t.Run(tc.Name, func(t *testing.T) {
+				tokens, err := token.Find(tc.Filter)
+				stubs.Must(t, "failed to list tokens", err)
+				stubs.AssertEquals(t, tc.Expected, tokens)
+			})
+		}
+	})
+}

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -18,18 +18,18 @@ var ErrTokenNotFound = fmt.Errorf("no token found")
 
 // NewTokenRequest is used to create a new token
 type NewTokenRequest struct {
-	UserID    string
-	ChannelID string
-	Text      string
+	UserID      string
+	ChannelLink string
+	Text        string
 }
 
 // Token is a persisted token
 type Token struct {
-	TokenID   string    `json:"token"`
-	UserID    string    `json:"userID"`
-	ChannelID string    `json:"channelID"`
-	Text      string    `json:"text"`
-	CreatedOn time.Time `json:"created_on"`
+	TokenID     string    `json:"token"`
+	UserID      string    `json:"userID"`
+	ChannelLink string    `json:"channelLink"`
+	Text        string    `json:"text"`
+	CreatedOn   time.Time `json:"created_on"`
 }
 
 // createUUID has been _honored_ from hashicorp UUID
@@ -60,11 +60,11 @@ func Create(r NewTokenRequest) (string, error) {
 		}
 
 		t := Token{
-			TokenID:   token,
-			UserID:    r.UserID,
-			ChannelID: r.ChannelID,
-			Text:      r.Text,
-			CreatedOn: time.Now(),
+			TokenID:     token,
+			UserID:      r.UserID,
+			ChannelLink: r.ChannelLink,
+			Text:        r.Text,
+			CreatedOn:   time.Now(),
 		}
 		tb, err := json.Marshal(t)
 		if err != nil {

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -1,4 +1,4 @@
-package token
+package tokens
 
 import (
 	"crypto/rand"

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -18,7 +18,7 @@ var ErrTokenNotFound = fmt.Errorf("no token found")
 
 // NewTokenRequest is used to create a new token
 type NewTokenRequest struct {
-	UserID      string
+	UserLink    string
 	ChannelLink string
 	Text        string
 }
@@ -26,7 +26,7 @@ type NewTokenRequest struct {
 // Token is a persisted token
 type Token struct {
 	TokenID     string    `json:"token"`
-	UserID      string    `json:"userID"`
+	UserLink    string    `json:"userLink"`
 	ChannelLink string    `json:"channelLink"`
 	Text        string    `json:"text"`
 	CreatedOn   time.Time `json:"created_on"`
@@ -61,7 +61,7 @@ func Create(r NewTokenRequest) (string, error) {
 
 		t := Token{
 			TokenID:     token,
-			UserID:      r.UserID,
+			UserLink:    r.UserLink,
 			ChannelLink: r.ChannelLink,
 			Text:        r.Text,
 			CreatedOn:   time.Now(),

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -19,8 +19,7 @@ var ErrTokenNotFound = fmt.Errorf("no token found")
 type NewTokenRequest struct {
 	User    string
 	Channel string
-	Command string
-	Args    []string
+	Text    string
 }
 
 // Token is a persisted token
@@ -28,8 +27,7 @@ type Token struct {
 	TokenID   string    `json:"token"`
 	User      string    `json:"user"`
 	Channel   string    `json:"channel"`
-	Command   string    `json:"command"`
-	Args      []string  `json:"args"`
+	Text      string    `json:"text"`
 	CreatedOn time.Time `json:"created_on"`
 }
 
@@ -64,8 +62,7 @@ func Create(r NewTokenRequest) (string, error) {
 			TokenID:   token,
 			User:      r.User,
 			Channel:   r.Channel,
-			Command:   r.Command,
-			Args:      r.Args,
+			Text:      r.Text,
 			CreatedOn: time.Now(),
 		}
 		tb, err := json.Marshal(t)

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/coreos/bbolt"
 	"github.com/pcarranza/meeseeks-box/db"
+	"github.com/sirupsen/logrus"
 )
 
 var tokensBucketKey = []byte("tokens")
@@ -70,6 +71,7 @@ func Create(r NewTokenRequest) (string, error) {
 			return fmt.Errorf("could not marshal token: %s", err)
 		}
 
+		logrus.Debugf("Creating token %#v", t)
 		return bucket.Put([]byte(token), tb)
 	})
 	return token, err
@@ -91,6 +93,7 @@ func Get(tokenID string) (Token, error) {
 
 		return json.Unmarshal(payload, &token)
 	})
+	logrus.Debugf("Returning token %#v with ID %s", token, tokenID)
 	return token, err
 }
 
@@ -130,5 +133,6 @@ func Find(filter Filter) ([]Token, error) {
 		}
 		return nil
 	})
+	logrus.Debugf("Looking up tokens, found %#v", tokens)
 	return tokens, err
 }

--- a/tokens/tokens.go
+++ b/tokens/tokens.go
@@ -17,16 +17,16 @@ var ErrTokenNotFound = fmt.Errorf("no token found")
 
 // NewTokenRequest is used to create a new token
 type NewTokenRequest struct {
-	User    string
-	Channel string
-	Text    string
+	UserID    string
+	ChannelID string
+	Text      string
 }
 
 // Token is a persisted token
 type Token struct {
 	TokenID   string    `json:"token"`
-	User      string    `json:"user"`
-	Channel   string    `json:"channel"`
+	UserID    string    `json:"userID"`
+	ChannelID string    `json:"channelID"`
 	Text      string    `json:"text"`
 	CreatedOn time.Time `json:"created_on"`
 }
@@ -60,8 +60,8 @@ func Create(r NewTokenRequest) (string, error) {
 
 		t := Token{
 			TokenID:   token,
-			User:      r.User,
-			Channel:   r.Channel,
+			UserID:    r.UserID,
+			ChannelID: r.ChannelID,
 			Text:      r.Text,
 			CreatedOn: time.Now(),
 		}

--- a/tokens/tokens_test.go
+++ b/tokens/tokens_test.go
@@ -10,10 +10,9 @@ import (
 func Test_TokenLifecycle(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			Command: "echo",
 			User:    "myuser",
 			Channel: "mychannel",
-			Args:    []string{"hello"},
+			Text:    "echo hello",
 		})
 		stubs.Must(t, "could not create token", err)
 		if id == "" {
@@ -24,20 +23,18 @@ func Test_TokenLifecycle(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		stubs.AssertEquals(t, id, tk.TokenID)
-		stubs.AssertEquals(t, "echo", tk.Command)
 		stubs.AssertEquals(t, "myuser", tk.User)
 		stubs.AssertEquals(t, "mychannel", tk.Channel)
-		stubs.AssertEquals(t, []string{"hello"}, tk.Args)
+		stubs.AssertEquals(t, "echo hello", tk.Text)
 	})
 }
 
 func Test_TokenListing(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			Command: "echo",
+			Text:    "echo something",
 			User:    "myuser",
 			Channel: "mychannel",
-			Args:    []string{"hello"},
 		})
 		stubs.Must(t, "could not create token", err)
 
@@ -45,10 +42,9 @@ func Test_TokenListing(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		id, err = tokens.Create(tokens.NewTokenRequest{
-			Command: "echo",
+			Text:    "echo something else",
 			User:    "someone_else",
 			Channel: "my_other_channel",
-			Args:    []string{"hello"},
 		})
 		stubs.Must(t, "could not create token", err)
 

--- a/tokens/tokens_test.go
+++ b/tokens/tokens_test.go
@@ -10,7 +10,7 @@ import (
 func Test_TokenLifecycle(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			UserID:      "myuser",
+			UserLink:    "myuser",
 			ChannelLink: "mychannel",
 			Text:        "echo hello",
 		})
@@ -23,7 +23,7 @@ func Test_TokenLifecycle(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		stubs.AssertEquals(t, id, tk.TokenID)
-		stubs.AssertEquals(t, "myuser", tk.UserID)
+		stubs.AssertEquals(t, "myuser", tk.UserLink)
 		stubs.AssertEquals(t, "mychannel", tk.ChannelLink)
 		stubs.AssertEquals(t, "echo hello", tk.Text)
 	})
@@ -33,7 +33,7 @@ func Test_TokenListing(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
 			Text:        "echo something",
-			UserID:      "myuser",
+			UserLink:    "myuser",
 			ChannelLink: "mychannel",
 		})
 		stubs.Must(t, "could not create token", err)
@@ -43,7 +43,7 @@ func Test_TokenListing(t *testing.T) {
 
 		id, err = tokens.Create(tokens.NewTokenRequest{
 			Text:        "echo something else",
-			UserID:      "someone_else",
+			UserLink:    "someone_else",
 			ChannelLink: "my_other_channel",
 		})
 		stubs.Must(t, "could not create token", err)
@@ -69,7 +69,7 @@ func Test_TokenListing(t *testing.T) {
 				Filter: tokens.Filter{
 					Limit: 5,
 					Match: func(tk tokens.Token) bool {
-						return tk.UserID == t2.UserID
+						return tk.UserLink == t2.UserLink
 					},
 				},
 			},

--- a/tokens/tokens_test.go
+++ b/tokens/tokens_test.go
@@ -1,15 +1,15 @@
-package token_test
+package tokens_test
 
 import (
 	"testing"
 
 	stubs "github.com/pcarranza/meeseeks-box/testingstubs"
-	"github.com/pcarranza/meeseeks-box/token"
+	"github.com/pcarranza/meeseeks-box/tokens"
 )
 
 func Test_TokenLifecycle(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
-		id, err := token.Create(token.NewTokenRequest{
+		id, err := tokens.Create(tokens.NewTokenRequest{
 			Command: "echo",
 			User:    "myuser",
 			Channel: "mychannel",
@@ -20,7 +20,7 @@ func Test_TokenLifecycle(t *testing.T) {
 			t.Fatal("create token returned an empty token id(?)")
 		}
 
-		tk, err := token.Get(id)
+		tk, err := tokens.Get(id)
 		stubs.Must(t, "could not get token back", err)
 
 		stubs.AssertEquals(t, id, tk.TokenID)
@@ -33,7 +33,7 @@ func Test_TokenLifecycle(t *testing.T) {
 
 func Test_TokenListing(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
-		id, err := token.Create(token.NewTokenRequest{
+		id, err := tokens.Create(tokens.NewTokenRequest{
 			Command: "echo",
 			User:    "myuser",
 			Channel: "mychannel",
@@ -41,10 +41,10 @@ func Test_TokenListing(t *testing.T) {
 		})
 		stubs.Must(t, "could not create token", err)
 
-		t1, err := token.Get(id)
+		t1, err := tokens.Get(id)
 		stubs.Must(t, "could not get token back", err)
 
-		id, err = token.Create(token.NewTokenRequest{
+		id, err = tokens.Create(tokens.NewTokenRequest{
 			Command: "echo",
 			User:    "someone_else",
 			Channel: "my_other_channel",
@@ -52,37 +52,37 @@ func Test_TokenListing(t *testing.T) {
 		})
 		stubs.Must(t, "could not create token", err)
 
-		t2, err := token.Get(id)
+		t2, err := tokens.Get(id)
 		stubs.Must(t, "could not get token back", err)
 
 		tt := []struct {
 			Name     string
-			Filter   token.Filter
-			Expected []token.Token
+			Filter   tokens.Filter
+			Expected []tokens.Token
 		}{
 			{
 				Name:     "empty list",
-				Expected: []token.Token{},
-				Filter: token.Filter{
+				Expected: []tokens.Token{},
+				Filter: tokens.Filter{
 					Limit: 0,
 				},
 			},
 			{
 				Name:     "filter by username works",
-				Expected: []token.Token{t2},
-				Filter: token.Filter{
+				Expected: []tokens.Token{t2},
+				Filter: tokens.Filter{
 					Limit: 5,
-					Match: func(tk token.Token) bool {
+					Match: func(tk tokens.Token) bool {
 						return tk.User == t2.User
 					},
 				},
 			},
 			{
 				Name:     "filter by channel works",
-				Expected: []token.Token{t1},
-				Filter: token.Filter{
+				Expected: []tokens.Token{t1},
+				Filter: tokens.Filter{
 					Limit: 5,
-					Match: func(tk token.Token) bool {
+					Match: func(tk tokens.Token) bool {
 						return tk.Channel == t1.Channel
 					},
 				},
@@ -90,9 +90,9 @@ func Test_TokenListing(t *testing.T) {
 		}
 		for _, tc := range tt {
 			t.Run(tc.Name, func(t *testing.T) {
-				tokens, err := token.Find(tc.Filter)
+				token, err := tokens.Find(tc.Filter)
 				stubs.Must(t, "failed to list tokens", err)
-				stubs.AssertEquals(t, tc.Expected, tokens)
+				stubs.AssertEquals(t, tc.Expected, token)
 			})
 		}
 	})

--- a/tokens/tokens_test.go
+++ b/tokens/tokens_test.go
@@ -10,9 +10,9 @@ import (
 func Test_TokenLifecycle(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			UserID:    "myuser",
-			ChannelID: "mychannel",
-			Text:      "echo hello",
+			UserID:      "myuser",
+			ChannelLink: "mychannel",
+			Text:        "echo hello",
 		})
 		stubs.Must(t, "could not create token", err)
 		if id == "" {
@@ -24,7 +24,7 @@ func Test_TokenLifecycle(t *testing.T) {
 
 		stubs.AssertEquals(t, id, tk.TokenID)
 		stubs.AssertEquals(t, "myuser", tk.UserID)
-		stubs.AssertEquals(t, "mychannel", tk.ChannelID)
+		stubs.AssertEquals(t, "mychannel", tk.ChannelLink)
 		stubs.AssertEquals(t, "echo hello", tk.Text)
 	})
 }
@@ -32,9 +32,9 @@ func Test_TokenLifecycle(t *testing.T) {
 func Test_TokenListing(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			Text:      "echo something",
-			UserID:    "myuser",
-			ChannelID: "mychannel",
+			Text:        "echo something",
+			UserID:      "myuser",
+			ChannelLink: "mychannel",
 		})
 		stubs.Must(t, "could not create token", err)
 
@@ -42,9 +42,9 @@ func Test_TokenListing(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		id, err = tokens.Create(tokens.NewTokenRequest{
-			Text:      "echo something else",
-			UserID:    "someone_else",
-			ChannelID: "my_other_channel",
+			Text:        "echo something else",
+			UserID:      "someone_else",
+			ChannelLink: "my_other_channel",
 		})
 		stubs.Must(t, "could not create token", err)
 
@@ -79,7 +79,7 @@ func Test_TokenListing(t *testing.T) {
 				Filter: tokens.Filter{
 					Limit: 5,
 					Match: func(tk tokens.Token) bool {
-						return tk.ChannelID == t1.ChannelID
+						return tk.ChannelLink == t1.ChannelLink
 					},
 				},
 			},

--- a/tokens/tokens_test.go
+++ b/tokens/tokens_test.go
@@ -10,9 +10,9 @@ import (
 func Test_TokenLifecycle(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			User:    "myuser",
-			Channel: "mychannel",
-			Text:    "echo hello",
+			UserID:    "myuser",
+			ChannelID: "mychannel",
+			Text:      "echo hello",
 		})
 		stubs.Must(t, "could not create token", err)
 		if id == "" {
@@ -23,8 +23,8 @@ func Test_TokenLifecycle(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		stubs.AssertEquals(t, id, tk.TokenID)
-		stubs.AssertEquals(t, "myuser", tk.User)
-		stubs.AssertEquals(t, "mychannel", tk.Channel)
+		stubs.AssertEquals(t, "myuser", tk.UserID)
+		stubs.AssertEquals(t, "mychannel", tk.ChannelID)
 		stubs.AssertEquals(t, "echo hello", tk.Text)
 	})
 }
@@ -32,9 +32,9 @@ func Test_TokenLifecycle(t *testing.T) {
 func Test_TokenListing(t *testing.T) {
 	stubs.WithTmpDB(func(_ string) {
 		id, err := tokens.Create(tokens.NewTokenRequest{
-			Text:    "echo something",
-			User:    "myuser",
-			Channel: "mychannel",
+			Text:      "echo something",
+			UserID:    "myuser",
+			ChannelID: "mychannel",
 		})
 		stubs.Must(t, "could not create token", err)
 
@@ -42,9 +42,9 @@ func Test_TokenListing(t *testing.T) {
 		stubs.Must(t, "could not get token back", err)
 
 		id, err = tokens.Create(tokens.NewTokenRequest{
-			Text:    "echo something else",
-			User:    "someone_else",
-			Channel: "my_other_channel",
+			Text:      "echo something else",
+			UserID:    "someone_else",
+			ChannelID: "my_other_channel",
 		})
 		stubs.Must(t, "could not create token", err)
 
@@ -69,7 +69,7 @@ func Test_TokenListing(t *testing.T) {
 				Filter: tokens.Filter{
 					Limit: 5,
 					Match: func(tk tokens.Token) bool {
-						return tk.User == t2.User
+						return tk.UserID == t2.UserID
 					},
 				},
 			},
@@ -79,7 +79,7 @@ func Test_TokenListing(t *testing.T) {
 				Filter: tokens.Filter{
 					Limit: 5,
 					Match: func(tk tokens.Token) bool {
-						return tk.Channel == t1.Channel
+						return tk.ChannelID == t1.ChannelID
 					},
 				},
 			},


### PR DESCRIPTION
This is a barebones implementation of an HTTP API server.

The way this is used is by creating a token that maps to a command with arguments on a channel, for example:

`token-new general echo hello!`

This will return a UUID (which is the token) that when called through the API server will launch the command as it was called in the general channel.

As a caveat, any bot will refuse to create a token in a non-IM channel because the token belongs to the calling user and effectively impersonates it.

There are still a couple of things to fix, which are:

- [x] recording the channel correctly when it comes throughout the API.
- [x] add a command to list tokens that belong to the user.
- [x] add a command to revoke a token that belongs to the user.