### PR TITLE
Cancel commands

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -3,6 +3,8 @@ package command
 import (
 	"time"
 
+	"context"
+
 	"github.com/pcarranza/meeseeks-box/jobs"
 )
 
@@ -13,7 +15,7 @@ const (
 
 // Command is the base interface for any command
 type Command interface {
-	Execute(job jobs.Job) (string, error)
+	Execute(context.Context, jobs.Job) (string, error)
 	Cmd() string
 	HasHandshake() bool
 	Templates() map[string]string

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -233,7 +233,7 @@ type cancelJobCommand struct {
 	noRecord
 	emptyArgs
 	allowAdmins
-	plainTemplates
+	defaultTemplates
 	defaultTimeout
 	cancelFunc func(jobID uint64)
 }
@@ -250,6 +250,13 @@ func (c cancelJobCommand) Execute(_ context.Context, job jobs.Job) (string, erro
 	jobID, err := parseJobID(job)
 	if err != nil {
 		return "", err
+	}
+	j, err := jobs.Get(jobID)
+	if err != nil {
+		return "", err
+	}
+	if j.Request.UserID != j.Request.UserID {
+		return "", jobs.ErrNoJobWithID
 	}
 	c.cancelFunc(jobID)
 	return fmt.Sprintf("Issued command cancellation to job %d", jobID), nil
@@ -650,7 +657,7 @@ type revokeAPITokenCommand struct {
 	defaultTimeout
 }
 
-func (r revokeAPITokenCommand) Execute(job jobs.Job) (string, error) {
+func (r revokeAPITokenCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
 	if !job.Request.IsIM {
 		return "", fmt.Errorf("API tokens can only be managed over an IM conversation, security ffs")
 	}
@@ -678,7 +685,7 @@ type listAPITokensCommand struct {
 var listTokensTemplate = `{{ if eq (len .tokens) 0 }}No tokens could be found{{ else }}{{ range $t := .tokens }}- *{{ $t.TokenID }}* {{ $t.UserLink }} at {{ $t.ChannelLink }} _{{ $t.Text}}_
 {{ end }}{{ end }}`
 
-func (l listAPITokensCommand) Execute(job jobs.Job) (string, error) {
+func (l listAPITokensCommand) Execute(_ context.Context, job jobs.Job) (string, error) {
 	if !job.Request.IsIM {
 		return "", fmt.Errorf("API tokens can only be managed over an IM conversation, security ffs")
 	}

--- a/commands/builtins/builtins.go
+++ b/commands/builtins/builtins.go
@@ -232,7 +232,7 @@ type cancelJobCommand struct {
 	noHandshake
 	noRecord
 	emptyArgs
-	allowAll
+	allowAdmins
 	plainTemplates
 	defaultTimeout
 	cancelFunc func(jobID uint64)

--- a/commands/builtins/builtins_test.go
+++ b/commands/builtins/builtins_test.go
@@ -1,6 +1,7 @@
 package builtins_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/pcarranza/meeseeks-box/auth"
@@ -257,7 +258,7 @@ func Test_BuiltinCommands(t *testing.T) {
 					t.Fatalf("could not find command %s", tc.cmd)
 				}
 
-				out, err := cmd.Execute(tc.job)
+				out, err := cmd.Execute(context.Background(), tc.job)
 				stubs.Must(t, "cmd erred out", err)
 				if tc.expected != "" {
 					stubs.AssertEquals(t, tc.expected, out)
@@ -301,7 +302,7 @@ func Test_FilterJobsAudit(t *testing.T) {
 			t.Fatalf("could not find command %s", "audit")
 		}
 
-		audit, err := cmd.Execute(jobs.Job{
+		audit, err := cmd.Execute(context.Background(), jobs.Job{
 			Request: request.Request{Args: []string{"-user", "someone"}},
 		})
 		if err != nil {
@@ -309,7 +310,7 @@ func Test_FilterJobsAudit(t *testing.T) {
 		}
 		stubs.AssertEquals(t, "*4* - now - *command* by *someone* in *<#123>* - *Running*\n*3* - now - *command* by *someone* in *<#123>* - *Running*\n*1* - now - *command* by *someone* in *<#123>* - *Running*\n", audit)
 
-		limit, err := cmd.Execute(jobs.Job{
+		limit, err := cmd.Execute(context.Background(), jobs.Job{
 			Request: request.Request{Args: []string{"-user", "someone", "-limit", "2"}},
 		})
 		if err != nil {

--- a/commands/shell/shell.go
+++ b/commands/shell/shell.go
@@ -38,10 +38,10 @@ type shellCommand struct {
 }
 
 // Execute implements Command.Execute for the ShellCommand
-func (c shellCommand) Execute(job jobs.Job) (string, error) {
+func (c shellCommand) Execute(ctx context.Context, job jobs.Job) (string, error) {
 	cmdArgs := append(c.Args(), job.Request.Args...)
 
-	ctx, cancelFunc := context.WithTimeout(context.Background(), c.Timeout())
+	ctx, cancelFunc := context.WithTimeout(ctx, c.Timeout())
 	defer cancelFunc()
 
 	AppendLogs := func(line string) {

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -1,9 +1,11 @@
 package meeseeks
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
+	"github.com/pcarranza/meeseeks-box/commands/builtins"
 	"github.com/sirupsen/logrus"
 
 	"github.com/pcarranza/meeseeks-box/command"
@@ -28,8 +30,9 @@ type Meeseeks struct {
 	messenger *messenger.Messenger
 	formatter *formatter.Formatter
 
-	tasksCh chan task
-	wg      sync.WaitGroup
+	tasksCh        chan task
+	wg             sync.WaitGroup
+	activeCommands *activeCommands
 }
 
 type task struct {
@@ -39,16 +42,20 @@ type task struct {
 
 // New creates a new Meeseeks service
 func New(client ChatClient, messenger *messenger.Messenger, formatter *formatter.Formatter) *Meeseeks {
+	ac := newActiveCommands()
+	commands.Add(builtins.BuiltinCancelJobCommand, builtins.NewCancelJobCommand(ac.Cancel))
+
 	m := Meeseeks{
 		messenger: messenger,
 		formatter: formatter,
 		client:    client,
 		tasksCh:   make(chan task, 20),
 
-		wg: sync.WaitGroup{},
+		wg:             sync.WaitGroup{},
+		activeCommands: ac,
 	}
 
-	go m.jobsLoop()
+	go m.loop()
 
 	return &m
 }
@@ -111,7 +118,7 @@ func (m *Meeseeks) closeTasksChannel() {
 	close(m.tasksCh)
 }
 
-func (m *Meeseeks) jobsLoop() {
+func (m *Meeseeks) loop() {
 	for t := range m.tasksCh {
 		go func(t task) {
 			job := t.job
@@ -120,7 +127,10 @@ func (m *Meeseeks) jobsLoop() {
 
 			m.replyWithHandshake(req, cmd)
 
-			out, err := t.cmd.Execute(t.job)
+			ctx := m.activeCommands.Add(t)
+			defer m.activeCommands.Cancel(job.ID)
+
+			out, err := t.cmd.Execute(ctx, t.job)
 			if err != nil {
 				logrus.Errorf("Command '%s' from user '%s' failed execution with error: %s",
 					req.Command, req.Username, err)
@@ -135,4 +145,41 @@ func (m *Meeseeks) jobsLoop() {
 			m.wg.Done()
 		}(t)
 	}
+}
+
+type activeCommands struct {
+	ctx map[uint64]context.CancelFunc
+	m   sync.Mutex
+}
+
+func newActiveCommands() *activeCommands {
+	return &activeCommands{
+		ctx: make(map[uint64]context.CancelFunc),
+	}
+}
+
+func (a *activeCommands) Add(t task) context.Context {
+	defer a.m.Unlock()
+	a.m.Lock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.ctx[t.job.ID] = cancel
+	return ctx
+}
+
+func (a *activeCommands) Cancel(jobID uint64) {
+	defer a.m.Unlock()
+	a.m.Lock()
+
+	cancel, ok := a.ctx[jobID]
+	if !ok {
+		logrus.Debugf("could not cancel job %d because it is not in the active jobs list", jobID)
+		return
+	}
+
+	// Delete the cancel command from the map
+	delete(a.ctx, jobID)
+
+	// Invoke the cancel function
+	cancel()
 }

--- a/meeseeks/meeseeks.go
+++ b/meeseeks/meeseeks.go
@@ -44,6 +44,7 @@ type task struct {
 func New(client ChatClient, messenger *messenger.Messenger, formatter *formatter.Formatter) *Meeseeks {
 	ac := newActiveCommands()
 	commands.Add(builtins.BuiltinCancelJobCommand, builtins.NewCancelJobCommand(ac.Cancel))
+	commands.Add(builtins.BuiltinKillJobCommand, builtins.NewKillJobCommand(ac.Cancel))
 
 	m := Meeseeks{
 		messenger: messenger,


### PR DESCRIPTION
This PR adds 2 new builtin commands, one called `cancel` that allows any user to cancel a running command owned by the calling user. Another called `kill` that allows admins to cancel any running command.

cc @omame 